### PR TITLE
Do not add ASCII NUL to the end of $0.

### DIFF
--- a/lib/loops/worker.rb
+++ b/lib/loops/worker.rb
@@ -36,7 +36,7 @@ module Loops
           @pid = Process.pid
           normal_exit = false
           begin
-            $0 = "loop worker: #{@name} ##{@index}\0"
+            $0 = "loop worker: #{@name} ##{@index}"
             @worker_block.call(self)
             normal_exit = true
             exit(0)


### PR DESCRIPTION
This fixes the following issue:

### Steps to reproduce:

1. Create a new Rails project.
2. Add to `Gemfile`:
```ruby
gem 'sinatra', :require => false
gem 'loops'
```
3. Create `lib/my_loop.rb` containing:
```ruby
class MyLoop < Loops::Base
  def run
    require 'sinatra'
    count = 0
    with_period_of(1) do
      count += 1
      puts "hello ##{count}!"
    end
  end
end
```
4. Create `config/loops.yml` containing:
```ruby
loops:
  my_loop:
    logger: default
```
5. Run `bundle exec loops start my_loop`

### Expected results:
Loop starts and runs.

### Actual results:
```
F : 2015-01-15 15:10:42 : 17741 : Worker exited with error: string contains null byte
  /Users/andrew/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/sinatra-1.4.5/lib/sinatra/main.rb:11:in `expand_path'
  /Users/andrew/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/sinatra-1.4.5/lib/sinatra/main.rb:11:in `block in <class:Application>'
  (eval):1:in `run?'
```

The issue is that [this line](https://github.com/kovyrin/loops/blob/7be51a58ca122e90d18551ee4f042e6c7a2b2919/lib/loops/worker.rb#L39) is adding an ASCII `NUL` to the end of the proctitle. Sinatra adds [a line](https://github.com/sinatra/sinatra/blob/5f6168bfc92280892e819df524d4508cf9032f6d/lib/sinatra/main.rb#L11) that calls `File.expand_path` on `$0`. `File.expand_path` raises an exception if its input contains any ASCII `NUL`s.

This effectively makes `loops` incompatible with any loop that loads Sinatra. My understanding is that the `NUL` was added to `$0` to support very old (~1.8.6) versions of Ruby that required it on certain operating systems. I’ve done quite a bit of Googling around, and, as far as I can tell, that does not appear to be required any more, or for quite a long time. (Try as I might, I cannot find any reference to it at all.) This very small change fixes the issue.