### PR TITLE
Improved configuration error reporting

### DIFF
--- a/lib/loops/engine.rb
+++ b/lib/loops/engine.rb
@@ -16,7 +16,7 @@ class Loops::Engine
     erb_config = ERB.new(raw_config).result
 
     @config = YAML.load(erb_config)
-    @loops_config  = @config['loops']
+    @loops_config  = @config['loops'] || raise("No data in 'loops' section in '#{Loops.config_file}'!")
 
     global_user_config = @config['global'] || {}
     @global_config = {
@@ -37,6 +37,8 @@ class Loops::Engine
 
     # Start all enabled loops
     loops_config.each do |name, loop_config|
+      loop_config ||= { }
+
       # Do not load the loop if it is disabled
       next if loop_config['disabled']
       next if loop_config.has_key?('enabled') && !loop_config['enabled']
@@ -151,7 +153,7 @@ class Loops::Engine
         the_logger = begin
             if Loops.logger.is_a?(Loops::Logger) && @global_config['workers_engine'] == 'fork'
               # this is happening right after the fork, therefore no need for teardown at the end of the proc
-              Loops.logger.logfile = config['logger']
+              Loops.logger.logfile = config['logger'] if config['logger']
               Loops.logger
             else
               # for backwards compatibility and handling threading engine


### PR DESCRIPTION
Fixes all the following issues (which I discovered by trying to do a quick-and-dirty loop test to validate a different issue):

1. Run `loops` with an empty file at `config/loops.yml`.

Before:
```
Unhandled exception: undefined method `[]' for false:FalseClass (NoMethodError)
/Users/andrew/Documents/Active/Employment/Swiftype/src.1/swiftype_loops/lib/loops/engine.rb:19:in `load_config'
```

Now:
```
Unhandled exception: No YAML at all in '/Users/andrew/Documents/Active/Employment/Swiftype/src.1/loopstest/config/loops.yml'? (RuntimeError)
/Users/andrew/Documents/Active/Employment/Swiftype/src.1/swiftype_loops/lib/loops/engine.rb:18:in `load_config'
```

2. Run `loops` with no `loop` section in `config/loops.yml`.

Before:
```
Unhandled exception: undefined method `[]' for nil:NilClass (NoMethodError)
/Users/andrew/Documents/Active/Employment/Swiftype/src.1/swiftype_loops/lib/loops/engine.rb:75:in `debug_loop!'
```

Now:
```
Unhandled exception: No data in 'loops' section in '/Users/andrew/Documents/Active/Employment/Swiftype/src.1/loopstest/config/loops.yml'! (RuntimeError)
/Users/andrew/Documents/Active/Employment/Swiftype/src.1/swiftype_loops/lib/loops/engine.rb:19:in `load_config'
```

3. Run `loops` with a loop declaration in `config/loops.yml` that has no `logger` section present.

Before:
```
Unhandled exception: no implicit conversion of nil into String (TypeError)
/Users/andrew/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/pathname.rb:389:in `initialize'
/Users/andrew/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/pathname.rb:389:in `new'
/Users/andrew/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/pathname.rb:389:in `join'
/Users/andrew/Documents/Active/Employment/Swiftype/src.1/swiftype_loops/lib/loops/logger.rb:72:in `logfile='
/Users/andrew/Documents/Active/Employment/Swiftype/src.1/swiftype_loops/lib/loops/engine.rb:154:in `block in start_loop'
```

Now:
Starts and runs correctly.
