### PR TITLE
Fixes 'Unhandled exception: no implicit conversion of Pathname into S…

### DIFF
--- a/lib/loops/engine.rb
+++ b/lib/loops/engine.rb
@@ -104,7 +104,7 @@ class Loops::Engine
     def load_loop_class(name, config)
       loop_name = config['loop_name'] || name
 
-      klass_files = [Loops.loops_root + "#{loop_name}_loop.rb", "#{loop_name}_loop"]
+      klass_files = [File.join(Loops.loops_root, "#{loop_name}_loop.rb"), "#{loop_name}_loop"]
       begin
         klass_file = klass_files.shift
         debug "Loading class file: #{klass_file}"


### PR DESCRIPTION
…tring (TypeError)' exception when running on Ruby 2.2.2.

I spotted the above issue after upgrading our Rails app to Ruby 2.2.2.  Concatenating a Pathname to a String, no longer 'casts' the Pathname to a String.  You either need to call Pathname#to_s, or use File#join.  I opted for the latter - hope it helps.